### PR TITLE
fix(broker): change the call of broker.kick from send to send_and_wait

### DIFF
--- a/taskiq_aio_kafka/broker.py
+++ b/taskiq_aio_kafka/broker.py
@@ -196,7 +196,7 @@ class AioKafkaBroker(AsyncBroker):
 
         topic_name: str = self._kafka_topic.name
 
-        await self._aiokafka_producer.send(
+        await self._aiokafka_producer.send_and_wait(
             topic=topic_name,
             value=message.message,
         )


### PR DESCRIPTION
# Summary

  - Replace AIOKafkaProducer.send with send_and_wait inside AioKafkaBroker.kick.
  - Ensures the broker call completes only after the producer receives broker ack or raises (timeouts/auth/SSL), instead of silently succeeding after buffering.

# Why
  Currently kick uses send, which enqueues to the local buffer and returns immediately; transport-level failures are not propagated, so middlewares may mark messages as sent even when the broker rejected them. send_and_wait follows the aiokafka recommended pattern and surfaces real send outcomes.

# Reference
  aiokafka docs: https://aiokafka.readthedocs.io/en/stable/producer.html

fixes: #8 